### PR TITLE
Version 0.38 - 2024-12-18

### DIFF
--- a/docs/GCG_attack/model_notes.md
+++ b/docs/GCG_attack/model_notes.md
@@ -376,33 +376,6 @@ Until this issue is resolved, Broken Hill will report one or more warnings when 
 * Will generally follow system prompt instructions that restrict information given to the user: TBD
   * Tool can generate adversarial content that defeats those restrictions: TBD
 
-##### Special considerations
-
-As of this writing, the current *release* of `fschat` (0.2.36 - from February 11th, 2024) did not support Llama-3, and the template requires custom logic. [You can install `fschat` from source](https://github.com/lm-sys/FastChat?tab=readme-ov-file#method-2-from-source) to enable the `llama-3` template, e.g. from the base directory where you created the Python virtual environment for Broken Hill:
-
-```
-git clone https://github.com/lm-sys/FastChat.git
-cd FastChat
-../bin/pip install -e ".[model_worker,webui]"
-cd ..
-```
-
-As with the Llama-2 conversation template, the `fschat` template for Llama-3 does not exactly match the output of the tokenizer's `apply_chat_template` function (for example, `fschat` adds an extra `<|eot_id|>` at the end of the prompt), but the differences shouldn't be enough to materially effect Broken Hill's test results. Until `fschat` is updated, Broken Hill will display a brief warning when the `llama-3` template is used.
-
-Llama-3.1's built-in `apply_chat_template` method incorporates the following odd system prompt by default (at least, for the `Meta-Llama-3.1-8B-Instruct` version, specifically):
-
-```
-Cutting Knowledge Date: December 2023
-Today Date: 26 Jul 2024
-
-```
-
-For maximum accuracy during your testing, you may want to replicate this, and can do so by adding the following option to refer to a file that's bundled with Broken Hill starting in version 0.32:
-
-```
---system-prompt-from-file BrokenHill/data/llama3_system_prompt.txt
-```
-
 ##### Specific models tested using Broken Hill:
 
 * [Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,10 +27,17 @@
 	  * You should have your Linux system set up with a working, reasonbly current version of [Nvidia's drivers and the CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit). One way to validate that the drivers and toolkit are working correctly is to try running [hashcat](https://hashcat.net/) in benchmarking mode. If you get results that are more or less like the results other hashcat users report for the same hardware, your drivers are probably working more or less correctly. If you see warnings or errors about the driver, "NVIDIA CUDA library", or "NVIDIA RTC library", you should troubleshoot those and get `hashcat` running without errors before proceeding.
   * For Windows:
     * You should have a reasonably recent version of the Nvidia drivers installed. We tested using the "Studio" version of the driver, without "Nvidia Experience".
-* If you want to have the smoothest possible setup and use experience, use Python 3.11.x when creating and using the `venv`. In particular, using another Python version may result in issues installing PyTorch.
+* **Only Python 3.11.x is supported at this time**. Using another Python version may result in issues with some of Broken Hill's third-party dependencies. If you are using another Python version, you should install the latest release of 3.11 in a side-by-side configuration and refer to the 3.11 binary explicitly when creating the Python virtual environment. Side-by-side Python version installation differs by platform, so if you're not already familiar with it, you'll need to do some web searching to determine what options you have and which approach you like best.
+  * On our test Debian system, we use `apt` to install multiple versions and then call the specific version we need in the shell.
+  * On our test Mac OS and Windows systems, we explicitly install the latest release of Python 3.11 (using `brew` on Mac OS and manual download/install on Windows) and don't have other Python versions installed. 
+* **Using a Python virtual environment (`venv`) is strongly recommended**, although that feature still doesn't seem to work on Windows. Broken Hill explicitly pins specific versions of third-party dependencies because so many of them are fragile and frequently introduce breaking changes. That means if you're using Python for anything *other* than Broken Hill, you're likely to run into dependency conflicts unless you use a virtual environment. If you can't use a Python virtual environment (e.g. because you're using Windows), you should create a separate user account specifically for Broken Hill, and install the dependencies in user mode instead of system-wide.
 * To install Broken Hill using the standard process on Windows, [you'll need a command-line Windows Git client, such as this package](https://git-scm.com/downloads/win).
 
 ## Setup
+
+Make sure you've read through the "Prerequisites" section, above.
+
+### Linux and Mac OS
 
 ```
 $ git clone https://github.com/BishopFox/BrokenHill
@@ -40,9 +47,9 @@ $ python -m venv ./
 $ bin/pip install ./BrokenHill/
 ```
 
-(for Windows, you will likely need to omit the `bin/` section of the `pip` and `python` commands throughout this documentation).
+### Windows
 
-### CUDA support for Windows
+#### CUDA support for Windows
 
 If you want to venture into the wild and try to get CUDA support working on Windows, [follow the PyTorch instructions for installing a CUDA-enabled version of PyTorch on your system](https://pytorch.org/get-started/locally/) before or after you install Broken Hill, e.g.:
 
@@ -52,9 +59,23 @@ pip install --force-reinstall torch --index-url https://download.pytorch.org/whl
 
 Performing this step *before* installing Broken Hill will save you time, because only one version of a fairly large Python library will be loaded.
 
-### `fschat` library
+#### Broken Hill setup for Windows
 
-The `pyproject.toml`-based configuration introduced in Broken Hill 0.34 automatically installs the `fschat` Python library from source to pick up newer conversation templates and other definitions, because as of this writing, the main branch of `fschat` has the same version number as the latest version in PyPi, but the code has been updated significantly for almost a year after the last PyPi release. If you want to install from PyPi instead, comment out this line in `pyproject.toml`:
+Windows still doesn't seem to support Python virtual environments, so you should create a user account specifically for Broken Hill and log in as that user account, then run:
+
+```
+$ git clone https://github.com/BishopFox/BrokenHill
+
+$ pip install --user ./BrokenHill/
+```
+
+You will also need to omit the `bin/` section of the `pip` and `python` commands throughout this documentation.
+
+### Optional - install `fschat` library from PyPi instead of source
+
+The `pyproject.toml`-based configuration used by versions of Broken Hill 0.34 and later automatically installs the `fschat` Python library from source to pick up newer conversation templates and other definitions, because as of this writing, the main branch of `fschat` has the same version number as the latest version in PyPi, but the code has been updated significantly for almost a year after the last PyPi release. **Most users should just install using `pyproject.toml` and skip to the `flash_attn` section, below**.
+
+*If you want to install the older version of `fschat` from PyPi instead for some reason* (for example, if the referenced GitHub repo is deleted), comment out this line in `pyproject.toml`:
 
 ```
   "fschat[model_worker,webui] @ git+https://github.com/lm-sys/FastChat",
@@ -68,7 +89,7 @@ The `pyproject.toml`-based configuration introduced in Broken Hill 0.34 automati
 
 ...then re-run `bin/pip install ./BrokenHill/`.
 
-### `flash_attn` library
+### Optional - install `flash_attn` library
 
 Some models will encourage you to install the `flash_attn` library. Broken Hill does not do this by default because some features of that library only support CUDA devices, and will cause Broken Hill to crash with arcane, obscure errors if - for example - it is used on a CPU device for testing purposes.
 

--- a/docs/all_command-line_options.md
+++ b/docs/all_command-line_options.md
@@ -738,3 +738,7 @@ When loading the model and tokenizer, pass `use_cache = True`. May or may not af
 ### --no-torch-cache
 
 When loading the model and tokenizer, pass `use_cache = False`. May or may not affect performance and results.
+
+## --preserve-gradient
+
+*Experimental* Retain the coordinate gradient between iterations of the attack instead of deleting it. This may result in increased device memory use.

--- a/llm_attacks_bishopfox/attack/attack_classes.py
+++ b/llm_attacks_bishopfox/attack/attack_classes.py
@@ -776,6 +776,7 @@ class AttackParams(JSONSerializableObject):
         # assorted values that may or may not impact performance
         self.low_cpu_mem_usage = False
         self.use_cache = True
+        self.preserve_gradient = False
     
         # various other minor configuration options
         # Displays the size of the model after loading it

--- a/llm_attacks_bishopfox/tests/test_classes.py
+++ b/llm_attacks_bishopfox/tests/test_classes.py
@@ -76,7 +76,7 @@ class BrokenHillTestParams(JSONSerializableObject):
         self.verbose_stats = True
         self.verbose_resource_info = True
         self.write_output_every_iteration = False
-        self.custom_options = [ '--exclude-nonascii-tokens', '--exclude-nonprintable-tokens', '--exclude-special-tokens', '--exclude-additional-special-tokens', '--exclude-newline-tokens', '--no-ansi' ]
+        self.custom_options = [ '--exclude-nonascii-tokens', '--exclude-nonprintable-tokens', '--exclude-special-tokens', '--exclude-additional-special-tokens', '--exclude-newline-tokens', '--no-ansi', '--preserve-gradient' ]
         # ten minute default for CUDA devices
         self.cuda_process_timeout = 600
         # default: one hour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brokenhill"
-version = "0.37.0"
+version = "0.38.0"
 description = "A productionized greedy coordinate gradient (GCG) attack tool for use against large language models (LLMs)."
 readme = "README.md"
 authors = [

--- a/tests/smoke_test-all_models.py
+++ b/tests/smoke_test-all_models.py
@@ -388,9 +388,14 @@ if __name__=='__main__':
     #smoke_test_params.console_level = "info"
     #smoke_test_params.log_level = "info"
     
-    # Remove all of the extra options that require building a denylist here
-    # Because it's easier to re-add them to the CUDA model test configs in the main loop instead of trying to remove them from the CPU model test configs there.
-    smoke_test_params.custom_options = [ "--no-ansi" ]
+    # # Remove all of the extra options that require building a denylist here
+    # # Because it's easier to re-add them to the CUDA model test configs in the main loop instead of trying to remove them from the CPU model test configs there.
+    # new_custom_options = []
+    # for i in range(0, len(smoke_test_params.custom_options)):
+        # current_option = smoke_test_params.custom_options[i]
+        # if "--exclude" not in current_option:
+            # new_custom_options.append(current_option)
+    # smoke_test_params.custom_options = new_custom_options
     
     if args.include_model:
         for elem in args.include_model:
@@ -409,6 +414,7 @@ if __name__=='__main__':
                         smoke_test_params.specific_model_names_to_skip = [ et ]
                     else:
                         smoke_test_params.specific_model_names_to_skip = add_value_to_list_if_not_already_present(smoke_test_params.specific_model_names_to_skip, et)
+    
     
     # 24 GiB of device memory == 25390809088
     # Largest model successfully tested so far with 24 GiB: 3821079552 parameters (Microsoft Phi-3 / 3.5 Mini 128k)

--- a/version_history.md
+++ b/version_history.md
@@ -1,5 +1,11 @@
 # Broken Hill version history
 
+# 0.38 - 2024-12-18
+
+* Added a warning message if the value specified for `--initial-adversarial-string` includes leading and/or trailing whitespace, in response to [issue #9](https://github.com/BishopFox/BrokenHill/issues/9).
+* Added an experimental `--preserve-gradient` option that retains the coordinate gradient between attack iterations.
+* Updated documentation to clarify some steps and strengthen the wording of prerequisites/dependencies.
+
 # 0.37 - 2024-11-18
 
 * Added support for the following additional models and model families:


### PR DESCRIPTION
* Added a warning message if the value specified for `--initial-adversarial-string` includes leading and/or trailing whitespace, in response to [issue #9](https://github.com/BishopFox/BrokenHill/issues/9).
* Added an experimental `--preserve-gradient` option that retains the coordinate gradient between attack iterations.
* Updated documentation to clarify some steps and strengthen the wording of prerequisites/dependencies.